### PR TITLE
adds custom previous/next icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ const styles = StyleSheet.create({
 | `modalStyles`         | Object   | null         | Custom styles for the modal. |
 | `chooseYearFirst`     | boolean  | false        | Opens the year selection modal first. |
 | `withoutModal`        | boolean  | false        | If true, the date picker will be displayed directly instead of being placed in a modal. |
+| `previousMonthIcon`   | ReactNode| -            | Any custom icon/text component you want to use
+| `nextMonthIcon        | ReactNode| -            | Any custom icon/text component you want to use
 
 ## <a name="onConfirm"></a>**`onConfirm`**
 

--- a/src/components/ModalHeader.tsx
+++ b/src/components/ModalHeader.tsx
@@ -13,6 +13,8 @@ interface Prop {
   toPrevMonth: () => void
   toNextMonth: () => void
   openYearModal: Dispatch<SetStateAction<boolean>>
+  previousMonthIcon?: React.ReactNode
+  nextMonthIcon?: React.ReactNode
 }
 
 const ModalHeader: FC<Prop> = ({
@@ -24,6 +26,8 @@ const ModalHeader: FC<Prop> = ({
   toPrevMonth,
   toNextMonth,
   openYearModal,
+  previousMonthIcon,
+  nextMonthIcon,
 }) => {
   const { headerColor, headerTextColor } = colors
   return (
@@ -37,11 +41,11 @@ const ModalHeader: FC<Prop> = ({
         disabled={!canGoPreviousMonth}
         onPress={toPrevMonth}
       >
-        <MDicon
+        {previousMonthIcon ? (previousMonthIcon) : <MDicon
           name={'keyboard-arrow-left'}
           size={32}
           color={headerTextColor}
-        />
+        />}
       </TouchableOpacity>
 
       {/* displayed year and month */}
@@ -61,11 +65,11 @@ const ModalHeader: FC<Prop> = ({
         disabled={!canGoNextMonth}
         onPress={toNextMonth}
       >
-        <MDicon
+        {nextMonthIcon ? (nextMonthIcon) : <MDicon
           name={'keyboard-arrow-right'}
           size={32}
           color={headerTextColor}
-        />
+        />}
       </TouchableOpacity>
     </View>
   )

--- a/src/components/NeatDatePicker.tsx
+++ b/src/components/NeatDatePicker.tsx
@@ -36,6 +36,8 @@ const NeatDatePicker = (props: NeatDatePickerProps) => {
     onCancel,
     onBackdropPress,
     onBackButtonPress,
+    previousMonthIcon,
+    nextMonthIcon,
   } = props
 
   dateStringFormat ??= 'yyyy-mm-dd'
@@ -283,6 +285,8 @@ const NeatDatePicker = (props: NeatDatePickerProps) => {
             openYearModal,
             canGoPreviousMonth,
             canGoNextMonth,
+            previousMonthIcon,
+            nextMonthIcon,
           }}
         />
 

--- a/src/components/NeatDatePicker.type.tsx
+++ b/src/components/NeatDatePicker.type.tsx
@@ -122,6 +122,17 @@ export type NeatDatePickerCommonProps = {
    */
   dateStringFormat?: string
 
+
+  /**
+   * The icon to use for the previous month button.
+   */
+  previousMonthIcon?: React.ReactNode
+
+  /**
+   * The icon to use for the next month button.
+   */
+  nextMonthIcon?: React.ReactNode
+
   /**
    * This callback will execute when user presses cancel button.
    *


### PR DESCRIPTION
There is an issue some people are experiencing (myself included) where the previous/next icons are not the chevrons we're expecting. This PR adds options to pass a `previousMonthIcon` and `nextMonthIcon` as props to the DatePicker.

[Issue here](https://github.com/roto93/react-native-neat-date-picker/issues/33)